### PR TITLE
Fix default selected server retrieval

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -282,7 +282,7 @@ exports.setClientToken = function(clientToken){
  * @returns {string} The ID of the selected serverpack.
  */
 exports.getSelectedServer = function(def = false){
-    return !def ? config.selectedServer : DEFAULT_CONFIG.clientToken
+    return !def ? config.selectedServer : DEFAULT_CONFIG.selectedServer
 }
 
 /**


### PR DESCRIPTION
## Summary
- fix ConfigManager.getSelectedServer returning wrong default

## Testing
- `npm run lint` *(fails: Module needs an import attribute of type json)*

------
https://chatgpt.com/codex/tasks/task_e_6841b699ed70832d8e1dd907fb3e8b4c