### PR TITLE
Fix typos in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you want to export the console output, simply right click anywhere on the con
 
 ## Development
 
-This section details the setup of a basic developmentment environment.
+This section details the setup of a basic development environment.
 
 ### Getting Started
 
@@ -87,7 +87,7 @@ This section details the setup of a basic developmentment environment.
 
 ```console
 > git clone https://github.com/Patrick15a/Random-Community-Launcher.git
-> cd HeliosLauncher
+> cd Random-Community-Launcher
 > npm install
 ```
 

--- a/docs/distro.md
+++ b/docs/distro.md
@@ -66,7 +66,7 @@ Global settings for [Discord Rich Presence](https://discordapp.com/developers/do
 **Properties**
 
 * `discord.clientId: string` - Client ID for th Application registered with Discord.
-* `discord.smallImageText: string` - Tootltip for the `smallImageKey`.
+* `discord.smallImageText: string` - Tooltip for the `smallImageKey`.
 * `discord.smallImageKey: string` - Name of the uploaded image for the small profile artwork.
 
 
@@ -134,7 +134,7 @@ Server specific settings used for [Discord Rich Presence](https://discordapp.com
 **Properties**
 
 * `discord.shortId: string` - Short ID for the server. Displayed on the second status line as `Server: shortId`
-* `discord.largeImageText: string` - Ttooltip for the `largeImageKey`.
+* `discord.largeImageText: string` - Tooltip for the `largeImageKey`.
 * `discord.largeImageKey: string` - Name of the uploaded image for the large profile artwork.
 
 ### `Server.mainServer: boolean`
@@ -186,7 +186,7 @@ Server-specific Java options.
 
 Platform-specific java rules for this server configuration. Validation rules will be delegated to the client for any undefined properties. Java validation can be configured for specific platforms and architectures. The most specific ruleset will be applied.
 
-Maxtrix Precedence (Highest - Lowest)
+Matrix Precedence (Highest - Lowest)
   - Current platform, current architecture (ex. win32 x64).
   - Current platform, any architecture (ex. win32).
   - Java Options base properties.


### PR DESCRIPTION
## Summary
- fix a typo in the development section of the README
- update directory name in setup instructions
- correct tooltip and precedence typos in `docs/distro.md`

## Testing
- `npm run lint` *(fails: Module `.eslintrc.json` needs import attribute `type: json`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b7fa6e7c832dac8376c04587de61