### PR TITLE
Fix expired token typo

### DIFF
--- a/app/assets/js/authmanager.js
+++ b/app/assets/js/authmanager.js
@@ -228,14 +228,14 @@ async function fullMicrosoftAuthFlow(entryCode, authMode) {
 
 /**
  * Calculate the expiry date. Advance the expiry time by 10 seconds
- * to reduce the liklihood of working with an expired token.
+ * to reduce the likelihood of working with an expired token.
  * 
  * @param {number} nowMs Current time milliseconds.
- * @param {number} epiresInS Expires in (seconds)
- * @returns 
+ * @param {number} expiresInS Expires in (seconds)
+ * @returns
  */
-function calculateExpiryDate(nowMs, epiresInS) {
-    return nowMs + ((epiresInS-10)*1000)
+function calculateExpiryDate(nowMs, expiresInS) {
+    return nowMs + ((expiresInS-10)*1000)
 }
 
 /**


### PR DESCRIPTION
## Summary
- correct typo in expiry calculation comment and parameter name

## Testing
- `npm run lint` *(fails: Module needs import attribute of type json)*
- `node -e "require('./app/assets/js/authmanager.js')"` *(fails: Cannot find module 'fs-extra')*

------
https://chatgpt.com/codex/tasks/task_e_6841b8211ebc832d841c09c7c1e73b64